### PR TITLE
Support session-based chat histories

### DIFF
--- a/src/backend/tarkiz_compass_api.py
+++ b/src/backend/tarkiz_compass_api.py
@@ -17,6 +17,7 @@ app.add_middleware(
 )
 class Query(BaseModel):
     text: str
+    session_id: str
 
 @app.post("/query")
 def process_query(query: Query):
@@ -25,7 +26,7 @@ def process_query(query: Query):
     # return {"answer": answer}
     try:
 
-        answer = handle_query(query.text)
+        answer = handle_query(query.text, query.session_id)
         return {"answer": answer}
     except Exception as e:
         print("BACKEND ERROR:", str(e))


### PR DESCRIPTION
## Summary
- Track chat histories by session identifier and clean up inactive sessions
- Accept session IDs through API to route queries

## Testing
- `python -m py_compile src/backend/tarkiz_compass_core.py src/backend/tarkiz_compass_api.py`


